### PR TITLE
Changed the API results_per_page from 0(all, which was probably dumb …

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -66,7 +66,7 @@ def authenticated_frontent_only_preprocessor(search_params=None, **kwargs):
 
 
 # Endpoints available at /api/<table_name>
-manager.create_api(Onions, methods=['POST', 'GET', 'PUT', 'PATCH'], results_per_page=0,
+manager.create_api(Onions, methods=['POST', 'GET', 'PUT', 'PATCH'], results_per_page=100,
                    allow_patch_many=True, allow_functions=True,
                    preprocessors=dict(GET_SINGLE=[authenticated_preprocessor],
                                       GET_MANY=[authenticated_preprocessor],
@@ -75,7 +75,7 @@ manager.create_api(Onions, methods=['POST', 'GET', 'PUT', 'PATCH'], results_per_
                                       PATCH=[authenticated_preprocessor],
                                       DELETE=[authenticated_preprocessor]))
 
-manager.create_api(Urls, methods=['POST', 'GET', 'PUT', 'PATCH'], results_per_page=0,
+manager.create_api(Urls, methods=['POST', 'GET', 'PUT', 'PATCH'], results_per_page=100,
                    allow_patch_many=True, allow_functions=True,
                    preprocessors=dict(GET_SINGLE=[authenticated_preprocessor],
                                       GET_MANY=[authenticated_preprocessor],
@@ -84,7 +84,7 @@ manager.create_api(Urls, methods=['POST', 'GET', 'PUT', 'PATCH'], results_per_pa
                                       PATCH=[authenticated_preprocessor],
                                       DELETE=[authenticated_preprocessor]))
 
-manager.create_api(Pages, methods=['POST', 'GET', 'PUT', 'PATCH'], results_per_page=0,
+manager.create_api(Pages, methods=['POST', 'GET', 'PUT', 'PATCH'], results_per_page=100,
                    allow_patch_many=True, allow_functions=True,
                    preprocessors=dict(GET_SINGLE=[authenticated_preprocessor],
                                       GET_MANY=[authenticated_preprocessor],
@@ -93,7 +93,7 @@ manager.create_api(Pages, methods=['POST', 'GET', 'PUT', 'PATCH'], results_per_p
                                       PATCH=[authenticated_preprocessor],
                                       DELETE=[authenticated_preprocessor]))
 
-manager.create_api(Forms, methods=['POST', 'GET', 'PUT', 'PATCH'], results_per_page=0,
+manager.create_api(Forms, methods=['POST', 'GET', 'PUT', 'PATCH'], results_per_page=100,
                    allow_patch_many=True, allow_functions=True,
                    preprocessors=dict(GET_SINGLE=[authenticated_preprocessor],
                                       GET_MANY=[authenticated_preprocessor],
@@ -102,7 +102,7 @@ manager.create_api(Forms, methods=['POST', 'GET', 'PUT', 'PATCH'], results_per_p
                                       PATCH=[authenticated_preprocessor],
                                       DELETE=[authenticated_preprocessor]))
 
-manager.create_api(Links, methods=['POST', 'GET', 'PUT', 'PATCH'], results_per_page=0,
+manager.create_api(Links, methods=['POST', 'GET', 'PUT', 'PATCH'], results_per_page=100,
                    allow_patch_many=True, allow_functions=True,
                    preprocessors=dict(GET_SINGLE=[authenticated_preprocessor],
                                       GET_MANY=[authenticated_preprocessor],
@@ -111,7 +111,7 @@ manager.create_api(Links, methods=['POST', 'GET', 'PUT', 'PATCH'], results_per_p
                                       PATCH=[authenticated_preprocessor],
                                       DELETE=[authenticated_preprocessor]))
 
-manager.create_api(Nodes, methods=['POST', 'GET', 'PUT', 'PATCH', 'DELETE'], results_per_page=0,
+manager.create_api(Nodes, methods=['POST', 'GET', 'PUT', 'PATCH', 'DELETE'], results_per_page=100,
                    allow_patch_many=True, allow_functions=True, allow_delete_many=True,
                    preprocessors=dict(GET_SINGLE=[authenticated_frontent_only_preprocessor],
                                       GET_MANY=[authenticated_frontent_only_preprocessor],


### PR DESCRIPTION
Changed the API results_per_page from 0(all, which was probably dumb ……anyways) to 100.  We had an issue where some random query would try to get all pages and all urls in the database, which would spike our memory and kill the webserver.